### PR TITLE
update streaming and basic pom.xml to add repository

### DIFF
--- a/DelhiJUG/PaymentEngine/basic/pom.xml
+++ b/DelhiJUG/PaymentEngine/basic/pom.xml
@@ -104,5 +104,10 @@
             </plugin>
         </plugins>
     </build>
-
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>

--- a/DelhiJUG/PaymentEngine/streaming/pom.xml
+++ b/DelhiJUG/PaymentEngine/streaming/pom.xml
@@ -98,5 +98,10 @@
             </plugin>
         </plugins>
     </build>
-
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
### Changes

add remote repository to streaming and basic `pom.xml`

```xml
    <repositories>
        <repository>
            <id>confluent</id>
            <url>https://packages.confluent.io/maven/</url>
        </repository>
    </repositories>
```

### Reason

i get an error while installing:


```
io.confluent:kafka-streams-avro-serde:jar:6.2.0 was not found 
in https://repo.maven.apache.org/maven2 during a previous attempt. 
This failure was cached in the local repository and resolution is not 
reattempted until the update interval of central 
has elapsed or updates are forced
```

or 

```
The POM for io.confluent:kafka-streams-avro-serde:jar:6.2.0 is missing, 
no dependency information available
```