### PR TITLE
update POM for M1 mac to Spring Boot 3.0.0

### DIFF
--- a/DelhiJUG/PaymentEngine/streaming/pom.xml
+++ b/DelhiJUG/PaymentEngine/streaming/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -16,7 +16,7 @@
     <description>streaming</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>
@@ -103,5 +103,40 @@
             <id>confluent</id>
             <url>https://packages.confluent.io/maven/</url>
         </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>


### PR DESCRIPTION
i had an error on M1 mac:

```
Could not initialize class org.rocksdb.DBOptions
```

The problem is: the rocksdb support of M1 is available from RocksDB 6.29.4.1

And for Kafka it is fixed in Kafka version 3.2.

But i don't get a Kafka version >= 3.2 with Spring Boot 2.7.2 - i got only Kafka version 3.1

I tried with 3.0.0-SNAPSHOT and i can start the `PaymentEngingeTopology` without error - and Effective POM print out kafka.version 3.2

NOTE: i don't tested it well - so i don't know if you can upgrade to 3.0 - but i created a Draft PR if someone have a similar error.

Related links:

- Description of rocksDB error: 
	https://github.com/facebook/rocksdb/issues/7720
- Announcement to Kafka 3.2 to work on M1:
	https://twitter.com/kafkastreams/status/1526613050568081410
- List of Spring Kafka versions with Kafka Clients version in Spring Boot versions:
	https://spring.io/projects/spring-kafka